### PR TITLE
Improve API design to be more conventional/performant

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,4 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { compress, decompress } from "./lzma.js";
+export { compress, compressString, decompress, decompressString, LZMA } from "./lzma.js";
+

--- a/lzma.test.ts
+++ b/lzma.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./index.js";
 import { LZMA } from "./lzma.js";
 
-function bytesToHexString(byteArray: Int8Array | Uint8Array | number[]): string {
+function bytesToHexString(byteArray: Uint8Array | Uint8Array | number[]): string {
 	return Array
 		.from(byteArray, (byte) => {
 			return ("0" + (byte & 0xFF).toString(16)).slice(-2);
@@ -84,7 +84,7 @@ describe("compress and decompress edge cases", () => {
 	});
 
 	test("binary data", () => {
-		const input = new Int8Array(1_000).map((_, i) => i % 256);
+		const input = new Uint8Array(1_000).map((_, i) => i % 256);
 		const compressed = compress(input, 1);
 		const decompressed = decompress(compressed);
 
@@ -165,7 +165,7 @@ describe("buffer handling", () => {
 		const compressed = compress(inputArray);
 		const decompressed = decompress(compressed);
 
-		assert.ok(decompressed instanceof Int8Array);
+		assert.ok(decompressed instanceof Uint8Array);
 
 		// Convert to string for comparison
 		const decoder = new TextDecoder();
@@ -179,7 +179,7 @@ describe("buffer handling", () => {
 		const compressed = compress(buffer);
 		const decompressed = decompress(compressed);
 
-		assert.ok(decompressed instanceof Int8Array);
+		assert.ok(decompressed instanceof Uint8Array);
 
 		// Convert to string for comparison
 		const decoder = new TextDecoder();
@@ -266,7 +266,7 @@ describe("edge case scenarios", () => {
 		} else {
 			assert.equal(decompressed.length, input.length);
 			for (let i = 0; i < input.length; i++) {
-				assert.equal(decompressed[i], input[i] < 128 ? input[i] : input[i] - 256);
+				assert.equal(decompressed[i], input[i]);
 			}
 		}
 	});
@@ -282,11 +282,8 @@ describe("edge case scenarios", () => {
 		const compressed = compress(input);
 		const decompressed = decompress(compressed);
 
-		// Int8Array will store values from -128 to 127, so values above 127
-		// will be represented as negative numbers (two's complement)
 		for (let i = 0; i < 256; i++) {
-			const expected = i < 128 ? i : i - 256;
-			assert.equal(decompressed[i], expected);
+			assert.equal(decompressed[i], i);
 		}
 	});
 });

--- a/lzma.test.ts
+++ b/lzma.test.ts
@@ -6,11 +6,13 @@ import {
 
 import {
 	compress,
+	compressString,
 	decompress,
+	decompressString
 } from "./index.js";
 import { LZMA } from "./lzma.js";
 
-function bytesToHexString(byteArray: Int8Array | Uint8Array): string {
+function bytesToHexString(byteArray: Int8Array | Uint8Array | number[]): string {
 	return Array
 		.from(byteArray, (byte) => {
 			return ("0" + (byte & 0xFF).toString(16)).slice(-2);
@@ -37,10 +39,10 @@ describe("basics", () => {
 		const fixtureInput = "hello world";
 		const fixtureOutput = "5d 00 00 01 00 0b 00 00 00 00 00 00 00 00 34 19 49 ee 8d e9 17 89 3a 33 60 05 f7 cf 64 ff fb 78 20 00";
 
-		const output = bytesToHexString(compress(fixtureInput, 1));
+		const output = bytesToHexString(compressString(fixtureInput, 1));
 		assert.equal(output, fixtureOutput);
 
-		const input = decompress(hexStringToUint8Array(fixtureOutput));
+		const input = decompressString(hexStringToUint8Array(fixtureOutput));
 		assert.equal(input, fixtureInput);
 	});
 
@@ -48,10 +50,10 @@ describe("basics", () => {
 		const fixtureInput = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 		const fixtureOutput = "5d 00 00 01 00 bd 01 00 00 00 00 00 00 00 26 1b ca 46 67 5a f2 77 b8 7d 86 d8 41 db 05 35 cd 83 a5 7c 12 a5 05 db 90 bd 2f 14 d3 71 72 96 a8 8a 7d 84 56 71 8d 6a 22 98 ab 9e 3d c3 55 ef cc a5 c3 dd 5b 8e bf 03 81 21 40 d6 26 91 02 45 4f 92 a1 78 bb 8a 00 af 90 2a 26 92 02 23 e5 5c b3 2d e3 e8 5c 2c fb 32 25 99 5c bc 71 f3 58 5a d3 1b 39 b4 bf 6f c7 61 36 92 14 e8 55 d3 ef 77 e0 68 fb ee 08 72 16 7e 2c ed 0a 69 78 8e 0c 1c 31 67 d5 b1 74 88 38 f5 e7 74 80 6e 7e 1e af 6d f5 32 22 17 bc da 0f a5 2f 85 48 72 02 fc b0 14 c7 16 aa ae cf 79 2a 0d 15 7f 49 1a e1 14 d4 9b 51 94 fc 9e 5d c1 1a 73 30 5c bc 65 2d d8 28 f9 09 73 cb f7 ad 4f 05 72 03 a5 6c 08 5b 36 26 fa 04 96 20 f5 4e 13 76 5f ce 4b 71 53 a7 5d 91 1b 1e 77 56 40 7e 91 de 51 72 0c 10 61 74 4b f6 6f 6e 90 6a 13 1f 99 fb 42 df 6a a8 94 52 cf 3d 77 cf 2f 21 62 cb f3 6b 5a fe fe 62 05 22 6c e8 df 9f de 8a 60 f3 7e 42 a6 24 48 d0 f3 ff 66 d3 e1 ed 4d d8 db 85 71 a3 ab c7 1b cd 67 22 b7 6b bc f2 7c 01 f0 48 a5 0c 38 9d 70 b4 e1 05 ff d6 30 7f f8";
 
-		const output = bytesToHexString(compress(fixtureInput, 1));
+		const output = bytesToHexString(compressString(fixtureInput, 1));
 		assert.equal(output, fixtureOutput);
 
-		const input = decompress(hexStringToUint8Array(output));
+		const input = decompressString(hexStringToUint8Array(output));
 		assert.equal(input, fixtureInput);
 	});
 });
@@ -59,24 +61,24 @@ describe("basics", () => {
 describe("compress and decompress edge cases", () => {
 	test("empty string", () => {
 		const input = "";
-		const compressed = compress(input, 1);
-		const decompressed = decompress(compressed);
+		const compressed = compressString(input, 1);
+		const decompressed = decompressString(compressed);
 
 		assert.equal(decompressed, input);
 	});
 
 	test("special characters", () => {
 		const input = "!@#$%^&*()_+-=[]{}|;':\",./<>?";
-		const compressed = compress(input, 1);
-		const decompressed = decompress(compressed);
+		const compressed = compressString(input, 1);
+		const decompressed = decompressString(compressed);
 
 		assert.equal(decompressed, input);
 	});
 
 	test("unicode characters", () => {
 		const input = "你好，世界！";
-		const compressed = compress(input, 1);
-		const decompressed = decompress(compressed);
+		const compressed = compressString(input, 1);
+		const decompressed = decompressString(compressed);
 
 		assert.equal(decompressed, input);
 	});
@@ -91,23 +93,23 @@ describe("compress and decompress edge cases", () => {
 
 	test("null character", () => {
 		const input = "\0";
-		const compressed = compress(input, 1);
-		const decompressed = decompress(compressed);
+		const compressed = compressString(input, 1);
+		const decompressed = decompressString(compressed);
 
 		assert.equal(decompressed, input);
 	});
 
 	test("repeated patterns", () => {
 		const input = "abcabcabc".repeat(100);
-		const compressed = compress(input, 1);
-		const decompressed = decompress(compressed);
+		const compressed = compressString(input, 1);
+		const decompressed = decompressString(compressed);
 		assert.equal(decompressed, input);
 	});
 
 	test("alternating patterns", () => {
 		const input = "10".repeat(500);
-		const compressed = compress(input, 1);
-		const decompressed = decompress(compressed);
+		const compressed = compressString(input, 1);
+		const decompressed = decompressString(compressed);
 		assert.equal(decompressed, input);
 	});
 });
@@ -120,8 +122,8 @@ describe("LZMA class direct usage", () => {
 
 	test("should compress and decompress without initializing LZMA class", () => {
 		const input = "Testing compression utilities";
-		const compressed = compress(input);
-		const decompressed = decompress(compressed);
+		const compressed = compressString(input);
+		const decompressed = decompressString(compressed);
 		assert.equal(decompressed, input);
 	});
 
@@ -130,8 +132,8 @@ describe("LZMA class direct usage", () => {
 
 		// Test all compression modes (1-9)
 		for (let mode = 1; mode <= 9; mode++) {
-			const compressed = compress(input, mode as any);
-			const decompressed = decompress(compressed);
+			const compressed = compressString(input, mode as any);
+			const decompressed = decompressString(compressed);
 			assert.equal(decompressed, input, `Failed with mode ${mode}`);
 		}
 	});
@@ -140,19 +142,19 @@ describe("LZMA class direct usage", () => {
 describe("large data compression", () => {
 	test("should handle large string input", () => {
 		const largeInput = "a".repeat(10000);
-		const compressed = compress(largeInput);
-		const decompressed = decompress(compressed);
+		const compressed = compressString(largeInput);
+		const decompressed = decompressString(compressed);
 		assert.equal(decompressed, largeInput);
 	});
 
 	test("should compress repeated data efficiently", () => {
 		const repeatedData = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".repeat(1000);
-		const compressed = compress(repeatedData);
+		const compressed = compressString(repeatedData);
 
 		// Verify compression ratio is good (compressed size should be much smaller)
 		assert.ok(compressed.length < repeatedData.length / 5);
 
-		const decompressed = decompress(compressed);
+		const decompressed = decompressString(compressed);
 		assert.equal(decompressed, repeatedData);
 	});
 });
@@ -163,18 +165,12 @@ describe("buffer handling", () => {
 		const compressed = compress(inputArray);
 		const decompressed = decompress(compressed);
 
-		// The decompressed result might be returned as a string instead of Int8Array
-		// since the LZMA engine tries to interpret the data
-		if (typeof decompressed === "string") {
-			assert.equal(decompressed, "Hello");
-		} else {
-			assert.ok(decompressed instanceof Int8Array);
+		assert.ok(decompressed instanceof Int8Array);
 
-			// Convert to string for comparison
-			const decoder = new TextDecoder();
-			const decompressedString = decoder.decode(decompressed);
-			assert.equal(decompressedString, "Hello");
-		}
+		// Convert to string for comparison
+		const decoder = new TextDecoder();
+		const decompressedString = decoder.decode(decompressed);
+		assert.equal(decompressedString, "Hello");
 	});
 
 	test("should handle ArrayBuffer input", () => {
@@ -183,17 +179,12 @@ describe("buffer handling", () => {
 		const compressed = compress(buffer);
 		const decompressed = decompress(compressed);
 
-		// The decompressed result might be returned as a string instead of Int8Array
-		if (typeof decompressed === "string") {
-			assert.equal(decompressed, "Hello World");
-		} else {
-			assert.ok(decompressed instanceof Int8Array);
+		assert.ok(decompressed instanceof Int8Array);
 
-			// Convert to string for comparison
-			const decoder = new TextDecoder();
-			const decompressedString = decoder.decode(decompressed);
-			assert.equal(decompressedString, "Hello World");
-		}
+		// Convert to string for comparison
+		const decoder = new TextDecoder();
+		const decompressedString = decoder.decode(decompressed);
+		assert.equal(decompressedString, "Hello World");
 	});
 });
 
@@ -202,16 +193,16 @@ describe("error handling", () => {
 		const inputs = ["a", "b", "c", "1", "2", "3"];
 
 		for (const input of inputs) {
-			const compressed = compress(input);
-			const decompressed = decompress(compressed);
+			const compressed = compressString(input);
+			const decompressed = decompressString(compressed);
 			assert.equal(decompressed, input, `Failed with input "${input}"`);
 		}
 	});
 
 	test("should handle inputs with mixed content types", () => {
 		const input = "Text with numbers 12345 and symbols !@#$%";
-		const compressed = compress(input);
-		const decompressed = decompress(compressed);
+		const compressed = compressString(input);
+		const decompressed = decompressString(compressed);
 		assert.equal(decompressed, input);
 	});
 });
@@ -230,8 +221,8 @@ describe("complex data structures", () => {
 		};
 
 		const jsonString = JSON.stringify(jsonObject);
-		const compressed = compress(jsonString);
-		const decompressed = decompress(compressed);
+		const compressed = compressString(jsonString);
+		const decompressed = decompressString(compressed);
 
 		assert.equal(decompressed, jsonString);
 		const parsedBack = JSON.parse(decompressed as string);
@@ -243,8 +234,8 @@ describe("complex data structures", () => {
 		const originalText = "This is some text that will be base64 encoded";
 		const base64 = Buffer.from(originalText).toString("base64");
 
-		const compressed = compress(base64);
-		const decompressed = decompress(compressed);
+		const compressed = compressString(base64);
+		const decompressed = decompressString(compressed);
 
 		assert.equal(decompressed, base64);
 		// Verify we can decode it back
@@ -291,25 +282,11 @@ describe("edge case scenarios", () => {
 		const compressed = compress(input);
 		const decompressed = decompress(compressed);
 
-		if (typeof decompressed === "string") {
-			// Convert the string back to binary for comparison
-			const binaryData = [];
-			for (let i = 0; i < decompressed.length; i++) {
-				binaryData.push(decompressed.charCodeAt(i));
-			}
-			// Only compare the valid byte values (some might be interpreted as UTF-8)
-			for (let i = 0; i < Math.min(256, binaryData.length); i++) {
-				if (i < 128) {
-					assert.equal(binaryData[i], i);
-				}
-			}
-		} else {
-			// Int8Array will store values from -128 to 127, so values above 127
-			// will be represented as negative numbers (two's complement)
-			for (let i = 0; i < 256; i++) {
-				const expected = i < 128 ? i : i - 256;
-				assert.equal(decompressed[i], expected);
-			}
+		// Int8Array will store values from -128 to 127, so values above 127
+		// will be represented as negative numbers (two's complement)
+		for (let i = 0; i < 256; i++) {
+			const expected = i < 128 ? i : i - 256;
+			assert.equal(decompressed[i], expected);
 		}
 	});
 });
@@ -330,8 +307,8 @@ describe("internal algorithm behavior", () => {
 			}
 		}
 
-		const compressed = compress(input);
-		const decompressed = decompress(compressed);
+		const compressed = compressString(input);
+		const decompressed = decompressString(compressed);
 		assert.equal(decompressed, input);
 	});
 });
@@ -343,7 +320,7 @@ describe("boundary condition tests", () => {
 		try {
 			// First compress valid data
 			const input = "Test data for corruption test";
-			const compressed = compress(input);
+			const compressed = compressString(input);
 
 			// Now corrupt the middle of the compressed data
 			const corruptedData = new Uint8Array(compressed.length);
@@ -379,8 +356,8 @@ describe("boundary condition tests", () => {
 		for (const offset of [-1, 0, 1]) {
 			const size = blockSize + offset;
 			const input = "A".repeat(size);
-			const compressed = compress(input);
-			const decompressed = decompress(compressed);
+			const compressed = compressString(input);
+			const decompressed = decompressString(compressed);
 			assert.equal(decompressed, input);
 		}
 	});

--- a/lzma.ts
+++ b/lzma.ts
@@ -3933,7 +3933,7 @@ export class LZMA {
 		];
 	}
 
-	#decode(utf: number[]): string | number[] {
+	#decodeString(utf: number[]): string {
 		let j = 0, x, y, z, l = utf.length, buf = [], charCodes = [];
 
 		for (let i = 0; i < l; ++i, ++j) {
@@ -3996,15 +3996,10 @@ export class LZMA {
 		return buf.join("");
 	}
 
-	encode(inputString: string | Uint8Array): number[] | Uint8Array {
+	encodeString(inputString: string): number[]  {
 		let ch, chars = [], elen = 0, l = inputString.length;
 
-		// Be able to handle binary arrays and buffers.
-		if (typeof inputString === "object") {
-			return inputString;
-		} else {
-			this.#getChars(inputString, 0, l, chars, 0);
-		}
+	  this.#getChars(inputString, 0, l, chars, 0);
 
 		// Add extra spaces in the array to break up the unicode symbols.
 		for (let i = 0; i < l; ++i) {
@@ -4038,61 +4033,102 @@ export class LZMA {
 	}
 
 	public compress(
-		data: string | Uint8Array | ArrayBuffer,
+		data: Uint8Array | ArrayBuffer,
 		mode: keyof typeof this.CompressionModes = 5,
-	): Int8Array {
-		const encodedData = this.encode(data);
+	): number[] {
 		const compressionMode = this.CompressionModes[mode];
 
 		this.#byteArrayCompressor(
-			encodedData,
+			data,
 			compressionMode,
 		);
 
 		while (this.#processChunkEncode());
 
 		const compressedByteArray = this.#toByteArray(this.#compressor.output);
-		return new Int8Array(compressedByteArray);
+		return compressedByteArray;
+	}
+
+  public compressString(
+		data: string,
+		mode: keyof typeof this.CompressionModes = 5,
+	): number[] {
+		const encodedData = this.encodeString(data);
+		return compress(encodedData, mode);
 	}
 
 	public decompress(
 		bytearray: Uint8Array | ArrayBuffer,
-	): Int8Array | string {
+	): number[] {
 		this.#byteArrayDecompressor(bytearray);
 
 		while (this.#processChunkDecode());
 
 		const decodedByteArray = this.#toByteArray(this.#decompressor.output);
-		const decoded = this.#decode(decodedByteArray);
+		return decodedByteArray;
+	}
 
-		return decoded instanceof Array
-			? new Int8Array(decoded)
-			: decoded;
+	public decompressString(
+		bytearray: Uint8Array | ArrayBuffer,
+	): string {
+		this.#byteArrayDecompressor(bytearray);
+
+		while (this.#processChunkDecode());
+
+		const decodedByteArray = this.#toByteArray(this.#decompressor.output);
+		const decoded = this.#decodeString(decodedByteArray);
+		return decoded;
 	}
 }
 
 /**
  * Compresses data using LZMA algorithm
  *
- * @param data Data to compress - can be string, Uint8Array or ArrayBuffer
+ * @param data Data to compress - can be Uint8Array or ArrayBuffer
  * @param mode Compression mode (1-9), defaults to 5
- * @returns Compressed data as Int8Array
+ * @returns Compressed data as a byte array
  */
 export function compress(
-	data: string | Uint8Array | ArrayBuffer,
+	data: Uint8Array | ArrayBuffer,
 	mode: keyof LZMA["CompressionModes"] = 5,
-): Int8Array {
+): Uint8Array {
 	const lzma = new LZMA();
-	return lzma.compress(data, mode);
+	return new Int8Array(lzma.compress(data, mode));
+}
+
+/**
+ * Compresses data using LZMA algorithm
+ *
+ * @param data String to compress
+ * @param mode Compression mode (1-9), defaults to 5
+ * @returns Compressed data as byte array
+ */
+export function compressString(
+	data: string,
+	mode: keyof LZMA["CompressionModes"] = 5,
+): Uint8Array {
+	const lzma = new LZMA();
+	return lzma.compressString(data, mode);
 }
 
 /**
  * Decompresses LZMA compressed data
  *
  * @param data Compressed data as Uint8Array or ArrayBuffer
- * @returns Decompressed data as string if input was string, or Int8Array if input was binary
+ * @returns Decompressed data
  */
-export function decompress(data: Uint8Array | ArrayBuffer): string | Int8Array {
+export function decompress(data: Uint8Array | ArrayBuffer): Uint8Array {
 	const lzma = new LZMA();
-	return lzma.decompress(data);
+	return new Int8Array(lzma.decompress(data));
+}
+
+/**
+ * Decompresses LZMA compressed data
+ *
+ * @param data Compressed data as Uint8Array or ArrayBuffer
+ * @returns Decompressed data as string
+ */
+export function decompressString(data: Uint8Array | ArrayBuffer): string {
+	const lzma = new LZMA();
+	return lzma.decompressString(data);
 }

--- a/lzma.ts
+++ b/lzma.ts
@@ -4093,7 +4093,7 @@ export function compress(
 	mode: keyof LZMA["CompressionModes"] = 5,
 ): Uint8Array {
 	const lzma = new LZMA();
-	return new Int8Array(lzma.compress(data, mode));
+	return new Uint8Array(lzma.compress(data, mode));
 }
 
 /**
@@ -4119,7 +4119,7 @@ export function compressString(
  */
 export function decompress(data: Uint8Array | ArrayBuffer): Uint8Array {
 	const lzma = new LZMA();
-	return new Int8Array(lzma.decompress(data));
+	return new Uint8Array(lzma.decompress(data));
 }
 
 /**


### PR DESCRIPTION
This PR fixes several problems with this otherwise solid LZMA implementation:

- The `decompress()` API attempted to "guess" whether the original uncompressed input was UTF text, and if so it returned a `string` instead of `number[]`. This is simply not a professional design.  API data types and _runtime behavior_ must be predictable (versus merely probably correct on a good day, if the inputs aren't maliciously crafted).

- For convenience, the code converted `number[]` to `Int8Array`.  For large objects, this could be a massive heap allocation.  I moved it out of the `LZMA` class and into the convenience API's only.

- I exported the `LZMA` class for people who care about performance.

- Replaced `Int8Array` with `Uint8Array` because the LZMA algorithm uses unsigned bytes, which is the standard for data compression algorithms.

## A related topic

Since LZMA compression can be very slow, I'd also like to suggest to add `async` APIs with % progress. We could copy the logic from the LZMA-JS `on_progress()` callback:

[LZMA-JS/src/lzma_worker.js](https://github.com/LZMA-JS/LZMA-JS/blob/8f98fe85a1ef78ab6e9d26ab85ce338f50095a23/src/lzma_worker.js#L2494-L2503)
```ts
    /** cs */
    function compress(str, mode, on_finish, on_progress) {
                . . .
                while ($processChunk(this$static.c.chunker)) {
                    percent = toDouble(this$static.c.chunker.inBytesProcessed) / toDouble(this$static.c.length_0);
                    /// If about 200 miliseconds have passed, update the progress.
                    if ((new Date()).getTime() - start > 200) {
                        on_progress(percent);
                        
                        wait(do_action, 0);
                        return 0;
                    }
                }
```

This isn't an essential feature; as long as the `LZMA` class is exported, an app could implement it externally.  But it would be convenient to have a built-in API.  If you're interested, it should be a separate PR from this one.

@xseman

